### PR TITLE
[Nextcloud] Fix PHP spare servers count

### DIFF
--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -48,4 +48,11 @@ RUN usermod -a -G users,usergroup0,usergroup1,usergroup2,usergroup3,usergroup4,u
 RUN sed -i 's/domain="coder" rights="none"/domain="coder" rights="read|write"/g' /etc/ImageMagick-6/policy.xml
 
 # FIX WARNING: [pool www] server reached pm.max_children setting (5), consider raising it
-RUN sed -i 's/pm.max_children = 5/pm.max_children = 50/g' /usr/local/etc/php-fpm.d/www.conf
+RUN sed -i 's/pm.max_children.*/pm.max_children = 50/g' /usr/local/etc/php-fpm.d/www.conf
+# FIX  WARNING: [pool www] seems busy (you may need to increase pm.start_servers, or pm.min/max_spare_servers), spawning 32 children, there are 0 idle, and 8 total children
+RUN sed -i 's/pm.min_spare_servers.*/pm.min_spare_servers = 5/g'  /usr/local/etc/php-fpm.d/www.conf
+RUN sed -i 's/pm.max_spare_servers.*/pm.max_spare_servers = 20/g' /usr/local/etc/php-fpm.d/www.conf
+RUN sed -i 's/pm.start_servers.*/pm.start_servers = 10/g'         /usr/local/etc/php-fpm.d/www.conf
+
+
+


### PR DESCRIPTION
WARNING: [pool www] seems busy (you may need to increase pm.start_servers, or pm.min/max_spare_servers), spawning 32 children, there are 0 idle, and 8 total children